### PR TITLE
feature(REPORT-11350): Gulp-version-update

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -3,6 +3,7 @@ const { exec } = require('shelljs');
 
 const ngCli = "node --max_old_space_size=4096 node_modules/@angular/cli/bin/ng";
 
-gulp.task('build', () => {
+gulp.task('build', (done) => {
   exec(`${ngCli} build`);
+  done();
 });

--- a/build/copy.js
+++ b/build/copy.js
@@ -9,9 +9,10 @@ const scripts = {
 const srcDir = 'node_modules/@boldreports/javascript-reporting-controls/Scripts/';
 const destDir = 'src/scripts/';
 
-gulp.task('copy', () => {
+gulp.task('copy', (done) => {
     copyFiles(scripts.common, destDir + 'common');
     copyFiles(scripts.control, destDir + 'data-visualization');
+    done();
 });
 
 function copyFiles(fileArray, dest) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,3 @@
-var gulp = require("gulp");
+const gulp = require("gulp");
 require('require-dir')('./build');
 module.exports = gulp;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/jquery": "3.3.29",
     "@types/node": "8.9.4",
     "codelyzer": "6.0.0",
-    "gulp": "3.9.1",
+    "gulp": "4.0.2",
     "jasmine-core": "3.6.0",
     "jasmine-spec-reporter": "5.0.0",
     "karma": "5.0.0",


### PR DESCRIPTION
<table>
<tr>
<td>
Description:
</td>
<td>
Upgrade-the-gulp-version-and-latest-version-gulp-tasks-integration
</td>
</tr>
<tr>
<td>
Analysis:
</td>
<td>
Analysis the latest gulp tasks
Analysis the existing automate-merge-request build tasks
</td>
</tr>
<tr>
<td>
Reason for not identifying earlier:
</td>
<td>
NA
</td>
</tr>
<tr>
<td>
Is it a breaking issue?
</td>
<td>
No
</td>
</tr>
<tr>
<td>
Solution description:
</td>
<td>
Convert the all tasks into latest gulp version
Gulp 4 version task integration
Every task should be a call back
changed the run-sequence into gulp4-run-sequence because run-sequence it wont support gulp4
update the gulp 4.0.2 version
declare every gulp task should be const not a var.
</td>
</tr>
<tr>
<td>
Areas affected and ensured:
</td>
<td>
NA
</td>
</tr>
<tr>
<td>
Test cases:
</td>
<td>
NA
</td>
</tr>
<tr>
<td>
Testbed sample location:
</td>
<td>
NA
</td>
</tr>
</table>